### PR TITLE
fix: use dev domain env var

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -57,14 +57,10 @@ app.delete('/tasks/:id', async (req, res) => {
 
     // Start the server.
     app.listen(config.API_PORT, () => {
-        let appUrl;
-
-        if (process.env.CODESPHERE_APP_ID) {
-            appUrl = `https://${process.env.CODESPHERE_APP_ID}-${config.API_PORT}.codesphere.com/`;
-        } else {
-            appUrl= `http://localhost:${config.API_PORT}/`;
-        }
-
+        const appUrl = process.env.WORKSPACE_DEV_DOMAIN
+            ? `https://${process.env.WORKSPACE_DEV_DOMAIN}/`
+            : `http://localhost:${config.API_PORT}/`;
+        
         console.info(`Ready! Follow the link to open your app: ${appUrl}`);
     });
 


### PR DESCRIPTION
The dev domain didn't include the datacenter ID.

Use the `WORKSPACE_DEV_DOMAIN`, which contains the complete dev deployment domain, including workspace ID, port and datacenter. Using this env var is also more resilient against future URL domain schema changes.

Thanks @QaysAyad for finding this bug.